### PR TITLE
initial commit, added minuteRange, secondRange, hourRange within the …

### DIFF
--- a/src/components/TimerPicker/index.tsx
+++ b/src/components/TimerPicker/index.tsx
@@ -40,6 +40,9 @@ export interface TimerPickerProps {
     hourLimit?: LimitType;
     minuteLimit?: LimitType;
     secondLimit?: LimitType;
+    hourRange?: number;
+    minuteRange?: number;
+    secondRange?: number;
     hourLabel?: string | React.ReactElement;
     minuteLabel?: string | React.ReactElement;
     secondLabel?: string | React.ReactElement;
@@ -65,6 +68,9 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
             hourLimit,
             minuteLimit,
             secondLimit,
+            hourRange,
+            minuteRange,
+            secondRange,
             hourLabel = "h",
             minuteLabel = "m",
             secondLabel = "s",
@@ -139,7 +145,7 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
                 {!hideHours ? (
                     <DurationScroll
                         ref={hoursDurationScrollRef}
-                        numberOfItems={23}
+                        numberOfItems={hourRange}
                         label={hourLabel}
                         initialValue={initialHours}
                         onDurationChange={setSelectedHours}
@@ -155,7 +161,7 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
                 {!hideMinutes ? (
                     <DurationScroll
                         ref={minutesDurationScrollRef}
-                        numberOfItems={59}
+                        numberOfItems={minuteRange}
                         label={minuteLabel}
                         initialValue={initialMinutes}
                         onDurationChange={setSelectedMinutes}
@@ -172,7 +178,7 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
                 {!hideSeconds ? (
                     <DurationScroll
                         ref={secondsDurationScrollRef}
-                        numberOfItems={59}
+                        numberOfItems={secondRange}
                         label={secondLabel}
                         initialValue={initialSeconds}
                         onDurationChange={setSelectedSeconds}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -40,6 +40,7 @@ export interface TimerPickerModalProps extends TimerPickerProps {
         seconds: number;
     }) => void;
     onCancel?: () => void;
+    setMinuteRange?: React.ComponentProps<typeof Number>
     closeOnOverlayPress?: boolean;
     hideCancelButton?: boolean;
     confirmButtonText?: string;
@@ -75,6 +76,9 @@ const TimerPickerModal = forwardRef<TimerPickerModalRef, TimerPickerModalProps>(
             hourLabel = "h",
             minuteLabel = "m",
             secondLabel = "s",
+            secRange = 59,
+            minRange = 59,
+            hrRange = 23,
             padWithNItems = 1,
             disableInfiniteScroll = false,
             hideCancelButton = false,
@@ -95,6 +99,9 @@ const TimerPickerModal = forwardRef<TimerPickerModalRef, TimerPickerModalProps>(
         ref
     ): React.ReactElement => {
         const styles = generateStyles(customStyles);
+        const [secondRange, setSecondRange] = useState(secRange)
+        const [minuteRange, setMinuteRange] = useState(minRange)
+        const [hourRange, setHourRange] = useState(hrRange)
 
         const [selectedDuration, setSelectedDuration] = useState({
             hours: initialHours,
@@ -185,6 +192,9 @@ const TimerPickerModal = forwardRef<TimerPickerModalRef, TimerPickerModalProps>(
                             hourLimit={hourLimit}
                             minuteLimit={minuteLimit}
                             secondLimit={secondLimit}
+                            hourRange={hourRange}
+                            minuteRange={minuteRange}
+                            secondRange={secondRange}
                             hourLabel={hourLabel}
                             minuteLabel={minuteLabel}
                             secondLabel={secondLabel}


### PR DESCRIPTION
…TimePicker component, could merge back to repo if working

Lightly tested throughout the UI, allows devs to create ranges dependent upon multiple different time selections.

minRange is not the best word so I can change these if a less misleading term is nessecary.