### PR TITLE
feat: allow to use a custom component for the FlatList

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ return (
 |          LinearGradient          | Linear Gradient Component                                                       | [expo-linear-gradient](https://www.npmjs.com/package/expo-linear-gradient).LinearGradient or [react-native-linear-gradient](https://www.npmjs.com/package/react-native-linear-gradient).default |    -    |  false   |
 |          Haptics          | Haptics Namespace (required for Haptic feedback)                                                     | [expo-haptics](https://www.npmjs.com/package/expo-haptics) |    -    |  false   |
 |          Audio          | Audio Class (required for audio feedback i.e. click sound)                                                     | [expo-av](https://www.npmjs.com/package/expo-av).Audio |    -    |  false   |
+|          FlatList          | FlatList component used internally to implement each picker (hour, minutes and seconds). More info [below](#custom-flatlist)                           | [react-native](https://reactnative.dev/docs/flatlist).FlatList |    `FlatList` from `react-native`    |  false   |
 |          clickSoundAsset          | Custom sound asset for click sound (required for offline click sound - download default [here](https://drive.google.com/uc?export=download&id=10e1YkbNsRh-vGx1jmS1Nntz8xzkBp4_I))                                              | require(.../somefolderpath) or {uri: www.someurl}    |    -    |  false   |
 |       pickerContainerProps       | Props for the picker container                                                  |                                                                               `React.ComponentProps<typeof View>`                                                                               |    -    |  false   |
 |    pickerGradientOverlayProps    | Props for both gradient overlays                                                |                                                                                 `Partial<LinearGradientProps>`                                                                                  |    -    |  false   |
@@ -428,6 +429,30 @@ The following custom styles can be supplied to re-style the component in any way
 |  pickerGradientOverlay  | Style for the gradient overlay (fade out)    |                ViewStyle                 |
 
 Note the minor limitations to the allowed styles for `pickerContainer` and `pickerItemContainer`. These are made because these styles are used for internal calculations and all possible `backgroundColor`/`height` types are not supported.
+
+
+#### Custom FlatList
+The library offers the chance of providing a custom component for the `<FlatList />` instead of the default one from `react-native`, this allows for more flexibility and integration with libraries like [react-native-gesture-handler](react-native-gesture-handler) or other components built on top of it, like [https://ui.gorhom.dev/components/bottom-sheet](https://ui.gorhom.dev/components/bottom-sheet).
+
+E.g. you want to place the timer picker within that bottom-sheet component, the scrolling detection from the bottom-sheet itself [would interfere](https://ui.gorhom.dev/components/bottom-sheet/troubleshooting#adding-horizontal-flatlist-or-scrollview-is-not-working-properly-on-android) with the one inside the timer picker, but it can be easily solved by providing the `FlatList` component from `react-native-gestire-handler` like this:
+
+```Jsx
+import { FlatList } from 'react-native-gesture-handler';
+import { TimerPicker } from "react-native-timer-picker";
+
+// ...
+
+<TimerPicker
+    {...props}
+    FlatList={FlatList}
+/>
+
+```
+
+And it will work as expected.
+
+**Important**:
+The custom component needs to have the same interface as `react-native` `<FlatList />` in order for it to work as expected, a complete reference of the current usage can be found [here](/src/components/DurationScroll/index.tsx)
 
 ### TimerPickerModal ⏰
 

--- a/src/components/DurationScroll/index.tsx
+++ b/src/components/DurationScroll/index.tsx
@@ -7,7 +7,7 @@ import React, {
     useEffect,
 } from "react";
 
-import { View, Text, FlatList } from "react-native";
+import { View, Text, FlatList as RNFlatList } from "react-native";
 import type {
     ViewabilityConfigCallbackPairs,
     ViewToken,
@@ -35,6 +35,7 @@ const DurationScroll = forwardRef<DurationScrollRef, DurationScrollProps>(
             bottomPickerGradientOverlayProps,
             clickSoundAsset,
             disableInfiniteScroll = false,
+            FlatList = RNFlatList,
             Haptics,
             initialValue = 0,
             is12HourPicker,
@@ -51,7 +52,6 @@ const DurationScroll = forwardRef<DurationScrollRef, DurationScrollProps>(
             styles,
             testID,
             topPickerGradientOverlayProps,
-            FlatListComponent = FlatList,
         } = props;
 
         const data = !is12HourPicker
@@ -84,7 +84,7 @@ const DurationScroll = forwardRef<DurationScrollRef, DurationScrollProps>(
         // keep track of the last index scrolled past for haptic/audio feedback
         const lastFeedbackIndex = useRef(0);
 
-        const flatListRef = useRef<FlatList | null>(null);
+        const flatListRef = useRef<RNFlatList | null>(null);
 
         const [clickSound, setClickSound] = useState<
             | {
@@ -370,7 +370,7 @@ const DurationScroll = forwardRef<DurationScrollRef, DurationScrollProps>(
                     isDisabled && styles.disabledPickerContainer,
                 ]}
                 testID={testID}>
-                <FlatListComponent
+                <FlatList
                     ref={flatListRef}
                     data={data}
                     decelerationRate={0.88}

--- a/src/components/DurationScroll/index.tsx
+++ b/src/components/DurationScroll/index.tsx
@@ -51,6 +51,7 @@ const DurationScroll = forwardRef<DurationScrollRef, DurationScrollProps>(
             styles,
             testID,
             topPickerGradientOverlayProps,
+            FlatListComponent = FlatList,
         } = props;
 
         const data = !is12HourPicker
@@ -369,7 +370,7 @@ const DurationScroll = forwardRef<DurationScrollRef, DurationScrollProps>(
                     isDisabled && styles.disabledPickerContainer,
                 ]}
                 testID={testID}>
-                <FlatList
+                <FlatListComponent
                     ref={flatListRef}
                     data={data}
                     decelerationRate={0.88}

--- a/src/components/DurationScroll/types.ts
+++ b/src/components/DurationScroll/types.ts
@@ -3,21 +3,22 @@ import type { MutableRefObject } from "react";
 
 import type {
     View,
-    FlatList,
+    FlatList as RNFlatList,
     FlatListProps as RNFlatListProps,
 } from "react-native";
 
 import type { generateStyles } from "../TimerPicker/styles";
 
-export type FlatListType = <ItemT = any>(
+export type CustomFlatList = <ItemT = any>(
     props: React.PropsWithChildren<
-        RNFlatListProps<ItemT> & React.RefAttributes<FlatList<ItemT>>
+        RNFlatListProps<ItemT> & React.RefAttributes<RNFlatList<ItemT>>
     >,
-    ref: React.ForwardedRef<FlatList<ItemT>>
+    ref: React.ForwardedRef<RNFlatList<ItemT>>
 ) => React.ReactElement | null;
 
 export interface DurationScrollProps {
     Audio?: any;
+    FlatList?: CustomFlatList;
     Haptics?: any;
     LinearGradient?: any;
     aggressivelyGetLatestDuration: boolean;
@@ -40,7 +41,6 @@ export interface DurationScrollProps {
     styles: ReturnType<typeof generateStyles>;
     testID?: string;
     topPickerGradientOverlayProps?: Partial<LinearGradientProps>;
-    FlatListComponent?: FlatListType;
 }
 
 export interface DurationScrollRef {

--- a/src/components/DurationScroll/types.ts
+++ b/src/components/DurationScroll/types.ts
@@ -1,9 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { MutableRefObject } from "react";
 
-import type { View } from "react-native";
+import type {
+    View,
+    FlatList,
+    FlatListProps as RNFlatListProps,
+} from "react-native";
 
 import type { generateStyles } from "../TimerPicker/styles";
+
+export type FlatListType = <ItemT = any>(
+    props: React.PropsWithChildren<
+        RNFlatListProps<ItemT> & React.RefAttributes<FlatList<ItemT>>
+    >,
+    ref: React.ForwardedRef<FlatList<ItemT>>
+) => React.ReactElement | null;
 
 export interface DurationScrollProps {
     Audio?: any;
@@ -29,6 +40,7 @@ export interface DurationScrollProps {
     styles: ReturnType<typeof generateStyles>;
     testID?: string;
     topPickerGradientOverlayProps?: Partial<LinearGradientProps>;
+    FlatListComponent?: FlatListType;
 }
 
 export interface DurationScrollRef {

--- a/src/components/TimerPicker/index.tsx
+++ b/src/components/TimerPicker/index.tsx
@@ -22,6 +22,7 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
             allowFontScaling = false,
             amLabel = "am",
             disableInfiniteScroll = false,
+            FlatList,
             hideHours = false,
             hideMinutes = false,
             hideSeconds = false,

--- a/src/components/TimerPicker/types.ts
+++ b/src/components/TimerPicker/types.ts
@@ -6,6 +6,7 @@ import type {
     LinearGradientProps,
     SoundAssetType,
     LimitType,
+    FlatListType,
 } from "../DurationScroll/types";
 
 import type { CustomTimerPickerStyles } from "./styles";
@@ -69,4 +70,5 @@ export interface TimerPickerProps {
     styles?: CustomTimerPickerStyles;
     topPickerGradientOverlayProps?: Partial<LinearGradientProps>;
     use12HourPicker?: boolean;
+    FlatListComponent?: FlatListType;
 }

--- a/src/components/TimerPicker/types.ts
+++ b/src/components/TimerPicker/types.ts
@@ -6,7 +6,7 @@ import type {
     LinearGradientProps,
     SoundAssetType,
     LimitType,
-    FlatListType,
+    CustomFlatList,
 } from "../DurationScroll/types";
 
 import type { CustomTimerPickerStyles } from "./styles";
@@ -31,6 +31,7 @@ export interface TimerPickerRef {
 export interface TimerPickerProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Audio?: any;
+    FlatList?: CustomFlatList;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Haptics?: any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,5 +71,4 @@ export interface TimerPickerProps {
     styles?: CustomTimerPickerStyles;
     topPickerGradientOverlayProps?: Partial<LinearGradientProps>;
     use12HourPicker?: boolean;
-    FlatListComponent?: FlatListType;
 }


### PR DESCRIPTION
Hello again!
I'd like to use this widget inside a `BottomSheet` from [https://ui.gorhom.dev/components/bottom-sheet/modal](https://ui.gorhom.dev/components/bottom-sheet/modal), but it doesn't work on Android.
The reason is that `react-native-timer-picker` uses `FlatList` and that doesn't go along really well with the bottomsheet lib implementation, the solution they suggest is to use their own version of `FlatList` [as described here](https://ui.gorhom.dev/components/bottom-sheet/troubleshooting#adding-horizontal-flatlist-or-scrollview-is-not-working-properly-on-android) instead of the default one from `react-native`.

So it would be great to have a prop to use a custom component for the FlatList, I made a simple PR with the needed changes.

The usage then becomes something like:
```JavaScript
import { FlatList } from "react-native-gesture-handler"

...

<TimerPicker
    hourLabel=":"
    minuteLabel=""
    secondLabel=""
    hideSeconds
    padWithNItems={1}
    initialValue={value}
    minuteLimit={{ min: 1 }}
    onDurationChange={onDurationChange}
    styles={styles.timePicker}
    FlatListComponent={FlatList}
/>
```

Let me know what you think about it.