### PR TITLE
fix: actually enable FlatList props to be passed down to TimerPicker

### DIFF
--- a/src/components/TimerPicker/index.tsx
+++ b/src/components/TimerPicker/index.tsx
@@ -22,7 +22,6 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
             allowFontScaling = false,
             amLabel = "am",
             disableInfiniteScroll = false,
-            FlatList,
             hideHours = false,
             hideMinutes = false,
             hideSeconds = false,

--- a/src/tests/TimerPicker.test.tsx
+++ b/src/tests/TimerPicker.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { render } from "@testing-library/react-native";
+import { FlatList } from "react-native";
 
 import TimerPicker from "../components/TimerPicker";
 
@@ -25,5 +26,16 @@ describe("TimerPicker", () => {
         const secondPicker = queryByTestId("duration-scroll-second");
         expect(minutePicker).toBeNull();
         expect(secondPicker).toBeNull();
+    });
+
+    it("uses the custom FlatList component when provided", () => {
+        const CustomFlatList = (props) => (
+            <FlatList {...props} testID="custom-flat-list" />
+        );
+        const { queryAllByTestId } = render(
+            <TimerPicker FlatList={CustomFlatList} />
+        );
+        const customFlatList = queryAllByTestId("custom-flat-list");
+        expect(customFlatList).toHaveLength(3);
     });
 });


### PR DESCRIPTION
Ops, my bad. 😅 

I put the `FlatList` prop in the destructuring, but then I forgot to passed it down explicitly, so it wasn't working.
I removed the declaration so it ends up inside `otherProps`.

I didn't spot it because I was working with a copy of the source code in my main project and then I replicated the changes on the original repo 🤦 

I added a simple test to make up for it 😁 