### PR TITLE
Added custom time scopes for time picker

### DIFF
--- a/src/components/TimerPicker/index.tsx
+++ b/src/components/TimerPicker/index.tsx
@@ -27,10 +27,12 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
             hideSeconds = false,
             hourLabel,
             hourLimit,
+            hourScope = 24,
             hoursPickerIsDisabled = false,
             initialValue,
             minuteLabel,
             minuteLimit,
+            minuteScope = 60,
             minutesPickerIsDisabled = false,
             onDurationChange,
             padHoursWithZero = false,
@@ -44,6 +46,7 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
             repeatSecondNumbersNTimes = 3,
             secondLabel,
             secondLimit,
+            secondScope = 60,
             secondsPickerIsDisabled = false,
             styles: customStyles,
             use12HourPicker = false,
@@ -156,7 +159,7 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
                             hourLabel ?? (!use12HourPicker ? "h" : undefined)
                         }
                         limit={hourLimit}
-                        numberOfItems={24}
+                        numberOfItems={hourScope}
                         onDurationChange={setSelectedHours}
                         padNumbersWithZero={padHoursWithZero}
                         padWithNItems={safePadWithNItems}
@@ -179,7 +182,7 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
                         isDisabled={minutesPickerIsDisabled}
                         label={minuteLabel ?? "m"}
                         limit={minuteLimit}
-                        numberOfItems={60}
+                        numberOfItems={minuteScope}
                         onDurationChange={setSelectedMinutes}
                         padNumbersWithZero={padMinutesWithZero}
                         padWithNItems={safePadWithNItems}
@@ -201,7 +204,7 @@ const TimerPicker = forwardRef<TimerPickerRef, TimerPickerProps>(
                         isDisabled={secondsPickerIsDisabled}
                         label={secondLabel ?? "s"}
                         limit={secondLimit}
-                        numberOfItems={60}
+                        numberOfItems={secondScope}
                         onDurationChange={setSelectedSeconds}
                         padNumbersWithZero={padSecondsWithZero}
                         padWithNItems={safePadWithNItems}

--- a/src/components/TimerPicker/types.ts
+++ b/src/components/TimerPicker/types.ts
@@ -47,6 +47,7 @@ export interface TimerPickerProps {
     hideSeconds?: boolean;
     hourLabel?: string | React.ReactElement;
     hourLimit?: LimitType;
+    hourScope?: number;
     hoursPickerIsDisabled?: boolean;
     initialValue?: {
         hours?: number;
@@ -55,6 +56,7 @@ export interface TimerPickerProps {
     };
     minuteLabel?: string | React.ReactElement;
     minuteLimit?: LimitType;
+    minuteScope?: number;
     minutesPickerIsDisabled?: boolean;
     onDurationChange?: (duration: {
         hours: number;
@@ -73,6 +75,7 @@ export interface TimerPickerProps {
     repeatSecondNumbersNTimes?: number;
     secondLabel?: string | React.ReactElement;
     secondLimit?: LimitType;
+    secondScope?: number;
     secondsPickerIsDisabled?: boolean;
     styles?: CustomTimerPickerStyles;
     topPickerGradientOverlayProps?: Partial<LinearGradientProps>;


### PR DESCRIPTION
Simple change to time picker, that allows user to pass custom time scope for each time unit.

This allows the library to be used in broader number of use cases, such as mine. I want it to be used to pick time limit, which can be up to 76 hours. This requirement also came up after I implemented such feature with this library, and I figured contributing would be easier than doing it from scratch.