### PR TITLE
Fix: hourLimit greying logic for PM hours and cross-midnight ranges in 12-hour picker

### DIFF
--- a/src/components/PickerItem/PickerItem.tsx
+++ b/src/components/PickerItem/PickerItem.tsx
@@ -40,6 +40,18 @@ const PickerItem = React.memo<PickerItemProps>(
       isAm = item.includes("AM");
       stringItem = item.replace(/\s[AP]M/g, "");
       intItem = parseInt(stringItem);
+
+      // Convert back to 24-hour value to match limit comparisons
+      if (!isAm && intItem !== 12) {
+        intItem += 12;
+      } else if (isAm && intItem === 12) {
+        intItem = 0;
+      }
+
+      // Handle cross-midnight overflow (e.g. limit.max = 29 meaning 5 AM next day)
+      if (adjustedLimitedMax >= 24 && intItem <= adjustedLimitedMax - 24) {
+        intItem += 24;
+      }
     }
 
     const isSelected = intItem === selectedValue;

--- a/src/tests/getAdjustedLimit.test.ts
+++ b/src/tests/getAdjustedLimit.test.ts
@@ -65,7 +65,7 @@ describe("getAdjustedLimit", () => {
   describe("out-of-bounds limits", () => {
     it("adjusts max when it exceeds maximum value", () => {
       const result = getAdjustedLimit({ max: 100, min: 5 }, 20, 1);
-      expect(result).toEqual({ max: 19, min: 5 });
+      expect(result).toEqual({ max: 100, min: 5 });
     });
 
     it("adjusts min when it is negative", () => {
@@ -75,12 +75,17 @@ describe("getAdjustedLimit", () => {
 
     it("adjusts both limits when out of bounds", () => {
       const result = getAdjustedLimit({ max: 100, min: -10 }, 20, 1);
-      expect(result).toEqual({ max: 19, min: 0 });
+      expect(result).toEqual({ max: 100, min: 0 });
     });
 
     it("adjusts max when only max is out of bounds", () => {
       const result = getAdjustedLimit({ max: 100 }, 20, 1);
-      expect(result).toEqual({ max: 19, min: 0 });
+      expect(result).toEqual({ max: 100, min: 0 });
+    });
+
+    it("allows max beyond maxValue for cross-midnight hour limits (e.g. 8 PM to 5 AM)", () => {
+      const result = getAdjustedLimit({ max: 29, min: 20 }, 24, 1);
+      expect(result).toEqual({ max: 29, min: 20 });
     });
 
     it("adjusts min when only min is out of bounds", () => {

--- a/src/utils/getAdjustedLimit.ts
+++ b/src/utils/getAdjustedLimit.ts
@@ -43,7 +43,7 @@ export const getAdjustedLimit = (
   }
 
   // guard against limits that are out of bounds
-  const adjustedMaxLimit = limit.max !== undefined ? Math.min(limit.max, maxValue) : maxValue;
+  const adjustedMaxLimit = limit.max !== undefined ? limit.max : maxValue;
   const adjustedMinLimit = limit.min !== undefined ? Math.max(limit.min, 0) : 0;
 
   // guard against invalid limits


### PR DESCRIPTION
Closes #82 

## Changes

- **`src/utils/getAdjustedLimit.ts`** — Removed `Math.min` clamp on `adjustedMaxLimit` 
  to allow cross-midnight hour ranges (e.g. max: 29 for 5 AM next day)

- **`src/components/PickerItem/PickerItem.tsx`** — Added 24-hour conversion after parsing 
  12-hour picker items so limit comparisons work correctly for PM hours and midnight overflow

- **`src/tests/getAdjustedLimit.test.ts`** — Updated 3 existing tests that assumed 
  out-of-bounds clamping, and added 1 new test for cross-midnight scenario

## Testing

Manually tested with:
- AM-only limit ✅
- PM-only limit ✅  
- Cross-midnight range (8 PM → 5 AM) ✅
- Default (no limit) ✅